### PR TITLE
When only files are selectable, allow selection by clicking on list tile. #8

### DIFF
--- a/package/lib/src/common.dart
+++ b/package/lib/src/common.dart
@@ -5,3 +5,10 @@ enum FilesystemType {
 }
 
 typedef ValueSelected = void Function(String value);
+
+/// Mode for selecting files. Either only the button in the trailing
+/// of ListTile, or onTap of the whole ListTile.
+enum FileTileSelectMode {
+  checkButton,
+  wholeTile,
+}

--- a/package/lib/src/filesystem_list.dart
+++ b/package/lib/src/filesystem_list.dart
@@ -13,6 +13,7 @@ class FilesystemList extends StatelessWidget {
   final List<String> allowedExtensions;
   final ValueChanged<Directory> onChange;
   final ValueSelected onSelect;
+  final FileTileSelectMode fileTileSelectMode;
 
   FilesystemList({
     Key key,
@@ -23,7 +24,9 @@ class FilesystemList extends StatelessWidget {
     this.allowedExtensions,
     @required this.onChange,
     @required this.onSelect,
-  }) : super(key: key);
+    @required this.fileTileSelectMode,
+  })  : assert(fileTileSelectMode != null),
+        super(key: key);
 
   Future<List<FileSystemEntity>> _dirContents() {
     var files = <FileSystemEntity>[];
@@ -84,6 +87,7 @@ class FilesystemList extends StatelessWidget {
                 folderIconColor: folderIconColor,
                 onChange: onChange,
                 onSelect: onSelect,
+                fileTileSelectMode: fileTileSelectMode,
               );
             },
           );

--- a/package/lib/src/filesystem_list_tile.dart
+++ b/package/lib/src/filesystem_list_tile.dart
@@ -11,6 +11,7 @@ class FilesystemListTile extends StatelessWidget {
   final Color folderIconColor;
   final ValueChanged<Directory> onChange;
   final ValueSelected onSelect;
+  final FileTileSelectMode fileTileSelectMode;
 
   FilesystemListTile({
     Key key,
@@ -19,7 +20,9 @@ class FilesystemListTile extends StatelessWidget {
     this.folderIconColor,
     @required this.onChange,
     @required this.onSelect,
-  }) : super(key: key);
+    @required this.fileTileSelectMode,
+  })  : assert(fileTileSelectMode != null),
+        super(key: key);
 
   Widget _leading(BuildContext context) {
     if (item is Directory) {
@@ -79,7 +82,8 @@ class FilesystemListTile extends StatelessWidget {
         title: Text(Path.basename(item.path), textScaleFactor: 1.2),
         onTap: (item is Directory)
             ? () => onChange(item)
-            : fsType == FilesystemType.file
+            : fsType == FilesystemType.file &&
+                    fileTileSelectMode == FileTileSelectMode.wholeTile
                 ? () => onSelect(item.absolute.path)
                 : null);
   }

--- a/package/lib/src/picker_page.dart
+++ b/package/lib/src/picker_page.dart
@@ -32,6 +32,7 @@ class FilesystemPicker extends StatefulWidget {
   /// * [permissionText] specifies the text of the message that there is no permission to access the storage, by default: "Access to the storage was not granted.".
   /// * [title] specifies the text of the dialog title.
   /// * [allowedExtensions] specifies a list of file extensions that will be displayed for selection, if empty - files with any extension are displayed. Example: `['.jpg', '.jpeg']`
+  /// * [fileTileSelectMode] specifies how to files can be selected (either tapping on the whole tile or only on trailing button). (default depends on [fsType])
   static Future<String> open({
     @required BuildContext context,
     @required Directory rootDirectory,
@@ -42,6 +43,7 @@ class FilesystemPicker extends StatefulWidget {
     String title,
     Color folderIconColor,
     List<String> allowedExtensions,
+    FileTileSelectMode fileTileSelectMode,
   }) async {
     final Completer<String> _completer = new Completer<String>();
 
@@ -60,6 +62,10 @@ class FilesystemPicker extends StatefulWidget {
             _completer.complete(value);
             Navigator.of(context).pop();
           },
+          fileTileSelectMode: fileTileSelectMode ??
+              (fsType == FilesystemType.file
+                  ? FileTileSelectMode.wholeTile
+                  : FileTileSelectMode.checkButton),
         );
       }),
     );
@@ -78,6 +84,7 @@ class FilesystemPicker extends StatefulWidget {
   final String title;
   final Color folderIconColor;
   final List<String> allowedExtensions;
+  final FileTileSelectMode fileTileSelectMode;
 
   FilesystemPicker({
     Key key,
@@ -90,7 +97,9 @@ class FilesystemPicker extends StatefulWidget {
     this.folderIconColor,
     this.allowedExtensions,
     @required this.onSelect,
-  }) : super(key: key);
+    @required this.fileTileSelectMode,
+  })  : assert(fileTileSelectMode != null),
+        super(key: key);
 
   @override
   _FilesystemPickerState createState() => _FilesystemPickerState();
@@ -204,6 +213,7 @@ class _FilesystemPickerState extends State<FilesystemPicker> {
                   allowedExtensions: widget.allowedExtensions,
                   onChange: _changeDirectory,
                   onSelect: widget.onSelect,
+                  fileTileSelectMode: widget.fileTileSelectMode,
                 )
               : Container(
                   alignment: Alignment.center,


### PR DESCRIPTION
Suggested change to let users select files by clicking on the whole list tile. #8

Imho, when using `fsType: FilesystemType.file` there is no confusion at all what happens on tap. If necessary I can introduce an additional parameter, maybe you can think of a parameter name. `fileWholeTileSelect` ? 😅️