### PR TITLE
remove explicit permission_handler dependency, replace with callback, move dependency to example.

### DIFF
--- a/package/example/lib/main.dart
+++ b/package/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:filesystem_picker/filesystem_picker.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 void main() => runApp(MyApp());
 
@@ -91,6 +92,8 @@ class _DemoPageState extends State<DemoPage> {
       folderIconColor: Colors.teal,
       allowedExtensions: ['.txt'],
       fileTileSelectMode: filePickerSelectMode,
+      requestPermission: () async =>
+          await Permission.storage.request().isGranted,
     );
 
     File file = File('$path');
@@ -111,6 +114,8 @@ class _DemoPageState extends State<DemoPage> {
       fsType: FilesystemType.folder,
       pickText: 'Save file to this folder',
       folderIconColor: Colors.teal,
+      requestPermission: () async =>
+          await Permission.storage.request().isGranted,
     );
 
     setState(() {
@@ -199,12 +204,13 @@ class _DemoPageState extends State<DemoPage> {
                     value: filePickerSelectMode == FileTileSelectMode.wholeTile,
                     onChanged: (bool newValue) => {
                       setState(() {
-                        filePickerSelectMode = newValue ? FileTileSelectMode.wholeTile : FileTileSelectMode.checkButton;
+                        filePickerSelectMode = newValue
+                            ? FileTileSelectMode.wholeTile
+                            : FileTileSelectMode.checkButton;
                       })
-                    },                    
+                    },
                   ),
                 ),
-
               ],
             ),
           ),

--- a/package/example/pubspec.yaml
+++ b/package/example/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider: ^1.1.0
+  permission_handler: ^5.0.1+1
   filesystem_picker:
     path: ../
 

--- a/package/lib/src/common.dart
+++ b/package/lib/src/common.dart
@@ -5,6 +5,7 @@ enum FilesystemType {
 }
 
 typedef ValueSelected = void Function(String value);
+typedef RequestPermission = Future<bool> Function();
 
 /// Mode for selecting files. Either only the button in the trailing
 /// of ListTile, or onTap of the whole ListTile.

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   flutter:
     sdk: flutter
   path: ^1.6.4
-  permission_handler: ^5.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Keeps the functionality the same, moves permission check into callback and moves `permission_handler` dependency to example. As discussed in #10 

I added the permission handler to the example, even though it works *completely the same* without it.. (except on android it gets rid of the permission dialog 🤷️) but I guess it would be necessary when setting `rootPath` to `getExternalStorageDirectory`. so maybe still worth the example..

(fyi did not update `pubspec.lock` files, because it seems i'm using a much newer flutter version and it should be ignored by the package anyway)