### PR TITLE
Do not explicitly style breadcrumps

### DIFF
--- a/package/lib/src/picker_page.dart
+++ b/package/lib/src/picker_page.dart
@@ -204,18 +204,7 @@ class _FilesystemPickerState extends State<FilesystemPicker> {
           onPressed: () => Navigator.of(context).pop(),
         ),
         bottom: PreferredSize(
-          child: Theme(
-            data: ThemeData(
-              textTheme: TextTheme(
-                button: TextStyle(
-                    color: AppBarTheme.of(context)
-                            .textTheme
-                            ?.headline6
-                            ?.color ??
-                        Theme.of(context).primaryTextTheme.headline6?.color),
-              ),
-            ),
-            child: Breadcrumbs<String>(
+          child: Breadcrumbs<String>(
               items: (!permissionRequesting && permissionAllowed)
                   ? pathItems
                       .map((path) => BreadcrumbItem<String>(
@@ -226,7 +215,6 @@ class _FilesystemPickerState extends State<FilesystemPicker> {
                 if (value != null) _changeDirectory(Directory(value));
               },
             ),
-          ),
           preferredSize: const Size.fromHeight(50),
         ),
       ),


### PR DESCRIPTION
When the breadcrumbs are a child of a inline theme they do not work anymore out of the box with other themes like [yaru.dart](https://github.com/ubuntu/yaru.dart)

This removes the theme parent and thus relies on the AppBar theme

Before:
![image](https://user-images.githubusercontent.com/15329494/135861160-fa5c38e9-7551-4749-bef2-5561dd03c9b6.png)

After:
![image](https://user-images.githubusercontent.com/15329494/135860984-a4bf5b25-f5d1-417c-b21e-bfa13115e938.png)
